### PR TITLE
fix: 투표 결과 정렬 로직 및 전체 데이터 반환 수정

### DIFF
--- a/src/main/java/com/workingdead/meet/dto/VoteResultDtos.java
+++ b/src/main/java/com/workingdead/meet/dto/VoteResultDtos.java
@@ -14,13 +14,13 @@ public class VoteResultDtos {
     
     // 순위별 정보
     public record RankingRes(
-            int rank,                    // 순위 (1, 2, 3)
-            LocalDate date,              // 날짜
-            String period,               // "LUNCH" or "DINNER"
-            int voteCount,               // 투표 인원 수
-            double priorityScore,        // 우선순위 가중치 합계
-            List<VoterDetailRes> voters  // 투표자 상세 (드롭다운용)
-    ) {}
+        Integer rank,                // 순위 (1, 2, 3, null) - null이면 4위 이하
+        LocalDate date,
+        String period,
+        int voteCount,
+        double priorityScore,
+        List<VoterDetailRes> voters
+        ) {}
     
     // 투표자 상세 정보
     public record VoterDetailRes(

--- a/src/main/java/com/workingdead/meet/repository/ParticipantSelectionRepository.java
+++ b/src/main/java/com/workingdead/meet/repository/ParticipantSelectionRepository.java
@@ -4,7 +4,15 @@ import com.workingdead.meet.entity.ParticipantSelection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 public interface ParticipantSelectionRepository extends JpaRepository<ParticipantSelection, Long> {
     List<ParticipantSelection> findByVoteId(Long voteId);
     List<ParticipantSelection> findByVoteIdAndParticipantId(Long voteId, Long participantId);
+
+    @Modifying
+    @Query("DELETE FROM ParticipantSelection ps WHERE ps.participant.id = :participantId")
+    void deleteByParticipantId(@Param("participantId") Long participantId);
 }

--- a/src/main/java/com/workingdead/meet/service/ParticipantService.java
+++ b/src/main/java/com/workingdead/meet/service/ParticipantService.java
@@ -149,6 +149,7 @@ public class ParticipantService {
         
         // participantRepository -> participantRepo로 수정!
         Participant saved = participantRepo.save(participant);
+        participantRepo.flush();
         
         // 5. 응답 생성
         List<ParticipantDtos.SelectionRes> selections = saved.getSelections().stream()

--- a/src/main/java/com/workingdead/meet/service/VoteResultService.java
+++ b/src/main/java/com/workingdead/meet/service/VoteResultService.java
@@ -37,7 +37,7 @@ public class VoteResultService {
         Map<String, List<ParticipantSelection>> groupedSelections = selections.stream()
                 .collect(Collectors.groupingBy(s -> keyOf(s.getDate(), s.getPeriod())));
         
-        // 4. 우선순위 맵 생성 (빠른 조회용)
+        // 4. 우선순위 맵 생성
         Map<String, Map<Long, PriorityPreference>> priorityMap = new HashMap<>();
         for (PriorityPreference pref : priorities) {
             String key = keyOf(pref.getDate(), pref.getPeriod());
@@ -47,26 +47,26 @@ public class VoteResultService {
         
         // 5. 각 날짜+시간대별 점수 계산
         List<SlotScore> slotScores = new ArrayList<>();
-        
+
         for (Map.Entry<String, List<ParticipantSelection>> entry : groupedSelections.entrySet()) {
-            String key = entry.getKey();
-            List<ParticipantSelection> slotSelections = entry.getValue();
-            
-            if (slotSelections.isEmpty()) continue;
-            
-            LocalDate date = slotSelections.get(0).getDate();
-            String period = slotSelections.get(0).getPeriod();
-            
-            int voteCount = slotSelections.size();
-            double priorityScore = 0.0;
-            
-            List<VoterDetailRes> voters = new ArrayList<>();
-            
-            for (ParticipantSelection selection : slotSelections) {
+        String key = entry.getKey();
+        List<ParticipantSelection> slotSelections = entry.getValue();
+        
+        if (slotSelections.isEmpty()) continue;
+        
+        LocalDate date = slotSelections.get(0).getDate();
+        String period = slotSelections.get(0).getPeriod();
+        
+        int voteCount = slotSelections.size();
+        double priorityScore = 0.0;
+        int priorityIndexSum = 0;  // 추가!
+        
+        List<VoterDetailRes> voters = new ArrayList<>();
+        
+        for (ParticipantSelection selection : slotSelections) {
                 Long participantId = selection.getParticipant().getId();
                 String participantName = selection.getParticipant().getDisplayName();
                 
-                // 우선순위 정보 확인
                 PriorityPreference pref = priorityMap.getOrDefault(key, Collections.emptyMap())
                         .get(participantId);
                 
@@ -74,38 +74,47 @@ public class VoteResultService {
                 Double weight = pref != null ? pref.getWeight() : null;
                 
                 if (weight != null) {
-                    priorityScore += weight;
+                priorityScore += weight;
+                }
+                
+                // priorityIndex 합계 (없으면 999로 처리해서 뒤로 밀림)
+                if (priorityIndex != null) {
+                priorityIndexSum += priorityIndex;
+                } else {
+                priorityIndexSum += 999;
                 }
                 
                 voters.add(new VoterDetailRes(participantId, participantName, priorityIndex, weight));
-            }
-            
-            slotScores.add(new SlotScore(date, period, voteCount, priorityScore, voters));
         }
         
-        // 6. 정렬: 최다 인원 > 우선순위 가중치 > 빠른 날짜
-        slotScores.sort(Comparator
-                .comparingInt(SlotScore::voteCount).reversed()
-                .thenComparingDouble(SlotScore::priorityScore).reversed()
-                .thenComparing(SlotScore::date));
-        
-        // 7. 상위 3개만 선택 및 순위 부여
-        List<RankingRes> rankings = new ArrayList<>();
-        List<SlotScore> top3 = slotScores.stream().limit(3).toList();
+        slotScores.add(new SlotScore(date, period, voteCount, priorityScore, priorityIndexSum, voters));
+        }
 
-for (int i = 0; i < top3.size(); i++) {
-    SlotScore slot = top3.get(i);
-    rankings.add(new RankingRes(
-            i + 1,                  // rank
-            slot.date(),
-            slot.period(),
-            slot.voteCount(),
-            slot.priorityScore(),
-            slot.voters()
-    ));
-}        
+        // 6. 정렬: 최다 인원 > priorityIndex 합계 작을수록 상위
+        slotScores.sort(Comparator
+                .comparingInt(SlotScore::voteCount).reversed()           // 1. 인원수 많은 순
+                .thenComparingInt(SlotScore::priorityIndexSum)           // 2. priorityIndex 합계 작은 순
+                .thenComparing(SlotScore::date));                        // 3. 날짜 빠른 순
+
+        // 7. 모든 결과에 순위 부여
+        List<RankingRes> rankings = new ArrayList<>();
+
+        for (int i = 0; i < slotScores.size(); i++) {
+        SlotScore slot = slotScores.get(i);
+        Integer rank = i < 3 ? (i + 1) : null;
+        
+        rankings.add(new RankingRes(
+                rank,
+                slot.date(),
+                slot.period(),
+                slot.voteCount(),
+                slot.priorityScore(),
+                slot.voters()
+        ));
+        }
+
         return new VoteResultRes(vote.getId(), vote.getName(), rankings);
-    }
+        }
     
     private String keyOf(LocalDate date, String period) {
         return date.toString() + "|" + period;
@@ -113,10 +122,12 @@ for (int i = 0; i < top3.size(); i++) {
     
     // 내부 DTO (정렬용)
     private record SlotScore(
-            LocalDate date,
-            String period,
-            int voteCount,
-            double priorityScore,
-            List<VoterDetailRes> voters
-    ) {}
+        LocalDate date,
+        String period,
+        int voteCount,
+        double priorityScore,
+        int priorityIndexSum,      // 추가!
+        List<VoterDetailRes> voters
+        ) {}
+    
 }


### PR DESCRIPTION
- 전체 투표 기록 반환 (rank 1~3과 null 구분)
- 정렬 기준: 최다 인원 > priorityIndex 합계(작을수록 상위) > 날짜
- 우선순위 미설정 시 999로 처리
- SlotScore에 priorityIndexSum 필드 추가

Fixes #16